### PR TITLE
Fix two small issues in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker run -it --rm --name tango_databaseds \
   -e MYSQL_HOST=mysql_db:3306 \
   -e MYSQL_USER=tango \
   -e MYSQL_PASSWORD=tango \
-  -e MYSQL_DATABASE=tango_db \
+  -e MYSQL_DATABASE=tango \
   tangocs/tango:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker run -it --rm --name tango_databaseds \
   -e MYSQL_USER=tango \
   -e MYSQL_PASSWORD=tango \
   -e MYSQL_DATABASE=tango \
-  tangocs/tango:latest
+  tangocs/tango-cs:latest
 ```
 
 Check the `.travis.yml` file to see how to set up a database inside a Docker


### PR DESCRIPTION
1. Changes `tangocs/tango:latest` to `tangocs/tango-cs:latest` in usage section, which reflects the name published on DockerHub
2. Changes `MYSQL_DATABASE=tango_db` to `MYSQL_DATABASE=tango`, which is in line with the tango-controls/docker-mysql project